### PR TITLE
[FIX] fix bug that app is crashed when take photo

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".CustomCamera2Activity">
+        <activity android:name=".CustomCamera2Activity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/camera/CameraController.java
+++ b/app/src/main/java/camera/CameraController.java
@@ -326,7 +326,11 @@ public class CameraController {
         mCompositeDisposable.add(Observable.combineLatest(previewObservable, mOnPauseSubject, (state, o) -> state)
             .firstElement().toObservable()
             .doOnNext(__ -> Log.d(TAG, "\ton pause"))
-            .doOnNext(captureSessionData -> captureSessionData.session.close())
+            .doOnNext(captureSessionData ->{
+                captureSessionData.session.stopRepeating();
+                captureSessionData.session.abortCaptures();
+                captureSessionData.session.close();
+            } )
             .flatMap(__ -> captureSessionClosedObservable)
             .doOnNext(cameraCaptureSession -> cameraCaptureSession.getDevice().close())
             .flatMap(__ -> closeCameraObservable)


### PR DESCRIPTION
add method **CameraCaptureSession.stopRepeating** and **captureSessionData.session.abortCapture()** when OnPause event is triggered